### PR TITLE
Renaming core systems

### DIFF
--- a/HDB_Gardening_Core.js
+++ b/HDB_Gardening_Core.js
@@ -31,8 +31,8 @@
  * =============================================================================
  * 
  * This plugin requires:
- * - HDB_Core_TimeClock.js
- * - HDB_Core_SaveTackOns.js
+ * - HDB_TimeClock_Core.js
+ * - HDB_SaveTackOns_Core.js
  * - YEP_EventSpawner.js
  * 
  * Make sure these plugins are loaded BEFORE this one in the plugin manager.
@@ -138,7 +138,7 @@
  */
 
 (function() {
-    let logger = window.HDB_Logger ? window.HDB_Logger.createLogger('HDB_Core_Gardening') : { log: () => {} };
+    let logger = window.HDB_Logger ? window.HDB_Logger.createLogger('HDB_Gardening_Core') : { log: () => {} };
 
     // Plant templates for spawning
     const PLANT_TEMPLATES = {

--- a/HDB_Logger_Core.js
+++ b/HDB_Logger_Core.js
@@ -1,6 +1,8 @@
 /*:
- * @plugindesc v1.0.0 Logging System Core for HDB plugins
+ * @plugindesc v1.0.0_beta Logging System for RPG Maker MV
  * @author HDB & Associates
+ * 
+ * @target MV
  * 
  * @help
  * HDB_Core_Logger.js

--- a/HDB_SaveTackOns_Core.js
+++ b/HDB_SaveTackOns_Core.js
@@ -67,7 +67,7 @@ let logger = null;
 
 (function() {
     // Initialize logger near the start of your IIFE
-    logger = window.HDB_Logger ? window.HDB_Logger.createLogger('HDB_Core_SaveTackOns') : { log: () => {} };
+    logger = window.HDB_Logger ? window.HDB_Logger.createLogger('HDB_SaveTackOns_Core') : { log: () => {} };
 
     // Version management
     const Version = {

--- a/HDB_TimeClock_Core.js
+++ b/HDB_TimeClock_Core.js
@@ -168,12 +168,12 @@
             this._lastUpdateTime = Date.now();
             
             // Load parameters first to get log level
-            const params = PluginManager.parameters('HDB_Core_TimeClock');
+            const params = PluginManager.parameters('HDB_TimeClock_Core');
             const logLevel = params.logLevel || 'ERROR';
             
             // Set up logger with correct log level
             if (window.HDB_Logger) {
-                this.logger = window.HDB_Logger.forPlugin('HDB_Core_TimeClock', logLevel);
+                this.logger = window.HDB_Logger.forPlugin('HDB_TimeClock_Core', logLevel);
                 this.logger.log('INFO', 'Time system logger initialized with level: ' + logLevel);
             }
             
@@ -186,7 +186,7 @@
         }
 
         loadParameters() {
-            const params = PluginManager.parameters('HDB_Core_TimeClock');
+            const params = PluginManager.parameters('HDB_TimeClock_Core');
             console.log('Raw plugin parameters:', params); // Debug log
             
             // Parse real minutes per game day with explicit type conversion and default value

--- a/HDB_TimeClock_Display.js
+++ b/HDB_TimeClock_Display.js
@@ -73,7 +73,7 @@
  * Plugin Dependencies
  * =============================================================================
  * 
- * This plugin requires HDB_Core_TimeClock.js to be loaded first.
+ * This plugin requires HDB_TimeClock_Core.js to be loaded first.
  * 
  * =============================================================================
  * Window Position


### PR DESCRIPTION
We can assume plugins are listed in alphabetical order, or can be. 

So I want "HDB" to be at the beginning of the filename. 

Then I want the plugin functionality to be the next part of the filename. 

Then either "Core" or whatever subset of functionality that particular plugin extension gives. 

In this way, the HDB plugin suite is grouped, the features are grouped, and you can still easily discern which plugin per feature should be loaded first. 

And of course you can sort the order in the plugin manager.